### PR TITLE
fix: render Google Maps iframe fallback on /kontakt when API key absent

### DIFF
--- a/components/GoogleMaps.tsx
+++ b/components/GoogleMaps.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-
+import { useTranslations } from "next-intl";
 import {
   APIProvider,
   Map,
@@ -9,62 +9,48 @@ import {
   useMarkerRef,
 } from "@vis.gl/react-google-maps";
 
-function MapFallback() {
+interface GoogleMapsProps {
+  lat: number;
+  lng: number;
+  address?: string;
+}
+
+function IframeMap({ lat, lng }: { lat: number; lng: number }) {
+  const t = useTranslations("map");
   return (
-    <div className="flex h-[50vh] min-h-[250px] w-full items-center justify-center rounded-lg border border-border bg-muted m-[2vh]">
-      <div className="flex flex-col items-center gap-3 px-4 text-center">
-        <p className="text-lg font-semibold text-foreground">Mapa niedostepna</p>
-        <p className="text-sm text-muted-foreground">
-          Ul. Ludwiki 4, 01-226 Warszawa
-        </p>
-        <a
-          href="https://www.google.com/maps/search/?api=1&query=Ludwiki+4+Warszawa"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground transition hover:bg-primary/90"
-        >
-          Otworz w Google Maps
-        </a>
-      </div>
-    </div>
+    <iframe
+      title={t("iframeTitle")}
+      src={`https://maps.google.com/maps?q=${lat},${lng}&z=15&output=embed`}
+      loading="lazy"
+      referrerPolicy="no-referrer-when-downgrade"
+      className="h-[50vh] min-h-[250px] w-full border-0"
+    />
   );
 }
 
-export const GoogleMaps = ({ lat, lng }: { lat: number; lng: number }) => {
+export const GoogleMaps = ({ lat, lng }: GoogleMapsProps) => {
   const [markerRef] = useMarkerRef();
-
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
 
   if (!apiKey) {
-    return (
-      <div className="flex h-full w-full items-center justify-between">
-        <MapFallback />
-      </div>
-    );
+    return <IframeMap lat={lat} lng={lng} />;
   }
 
   return (
-    <div className="flex h-full w-full items-center justify-between">
-      <APIProvider apiKey={apiKey}>
-        <Map
-          style={{
-            width: "100%",
-            height: "50vh",
-            minHeight: "250px",
-            margin: "2vh",
-            padding: "0",
-          }}
-          defaultCenter={{ lat: lat, lng: lng }}
-          defaultZoom={15}
-          gestureHandling={"greedy"}
-          disableDefaultUI={true}
-        >
-          <Marker
-            ref={markerRef}
-            position={{ lat: lat, lng: lng }}
-          />
-        </Map>
-      </APIProvider>
-    </div>
+    <APIProvider apiKey={apiKey}>
+      <Map
+        style={{
+          width: "100%",
+          height: "50vh",
+          minHeight: "250px",
+        }}
+        defaultCenter={{ lat, lng }}
+        defaultZoom={15}
+        gestureHandling="greedy"
+        disableDefaultUI
+      >
+        <Marker ref={markerRef} position={{ lat, lng }} />
+      </Map>
+    </APIProvider>
   );
 };

--- a/messages/en.json
+++ b/messages/en.json
@@ -566,5 +566,10 @@
   },
   "loading": {
     "logoAlt": "logo"
+  },
+  "map": {
+    "iframeTitle": "Location map",
+    "unavailableTitle": "Map unavailable",
+    "openInGoogleMaps": "Open in Google Maps"
   }
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -566,5 +566,10 @@
   },
   "loading": {
     "logoAlt": "logo"
+  },
+  "map": {
+    "iframeTitle": "Mapa lokalizacji",
+    "unavailableTitle": "Mapa niedostępna",
+    "openInGoogleMaps": "Otwórz w Google Maps"
   }
 }


### PR DESCRIPTION
## Summary
`/kontakt` and `/en/kontakt` currently show a \"Mapa niedostępna\" card in production because \`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY\` isn't set on Vercel. The Mirów page and the apartment-detail \"Location\" tab already handle this case by falling back to a public Google Maps embed iframe — `GoogleMaps.tsx` didn't. This makes it consistent.

Setting the API key on Vercel will restore the rich interactive map; this PR ensures the no-key state still looks polished.

## Changes
- `components/GoogleMaps.tsx` — when `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is missing, render a `maps.google.com/maps?q=…&output=embed` iframe instead of a static \"map unavailable\" card. Drop the unused `MapFallback` markup and the redundant outer flex wrapper.
- `messages/{pl,en}.json` — add a `map` namespace (`iframeTitle`, `unavailableTitle`, `openInGoogleMaps`) for the iframe title and any future fallback copy.

## Test plan
- [x] `npm run build` — clean
- [ ] After deploy: `/kontakt` and `/en/kontakt` show an interactive embedded map centred on Ludwiki 4, Warszawa (no API key required)
- [ ] Apartment detail \"Location\" tab — confirm the embed renders correctly there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)